### PR TITLE
chore: `.gitignore` improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .gitignored/
 typefaces/
-.idea/
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gitignored/
+dist/
 node_modules/
 typefaces/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .gitignored/
-typefaces/
 node_modules/
+typefaces/*


### PR DESCRIPTION
- We don't need to ignore `.idea/`, that's ignored globally.
- Add `.gitkeep` to `typefaces/` so the directory is preserved.
- Ignore the `dist/` directory for build output.
