### PR TITLE
refactor: typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
 </svg>
 
     <!-- Above the fold -->
-    <h1 class="headline">
+    <h1 class="hed">
         <span class="emoji-container"><span class="emoji">👋</span></span> Hello!
     </h1>
     <p>I'm <strong>Luke</strong>—a software engineer living in 📍 <a href="https://maps.apple.com/?address=Central%20Otago%20District,%20New%20Zealand">Central Otago, New Zealand</a>.</p>

--- a/styles/global.css
+++ b/styles/global.css
@@ -15,7 +15,7 @@ html {
 body {
     color: var(--primary-text--light-appearance);
     background-color: var(--primary-bg--light-appearance);
-    font-family: var(--primary-typeface);
+    font-family: var(--text-typeface);
     font-size: 1.1em;
     font-weight: 400;
     line-height: 1.5;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,4 +1,5 @@
-.headline {
+.hed {
     /* Introduce some margin such that emojis are positioned naturally to the headline text. */
     margin-inline-start: 1.25em;
+    font: bold 4em var(--display-typeface);
 }

--- a/styles/type.css
+++ b/styles/type.css
@@ -1,70 +1,80 @@
 @font-face {
-    font-family: 'Neue Haas Grotesk Display Pro';
-    font-weight: 100;
-    src: local('Neue Haas Grotesk Display Pro 15 Ultra Thin'),
-    url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-15UltTh.otf') format('opentype');
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-weight: 100;
+  src: local('Neue Haas Grotesk Display Pro 15 Ultra Thin'),
+  url('../typefaces/neue-haas-grotesk-display/woff2/NHaasGroteskDSPro-15UltTh.woff2') format('woff2'),
+  url('../typefaces/neue-haas-grotesk-display/otf/NHaasGroteskDSPro-15UltTh.otf') format('opentype');
 }
 
 @font-face {
-    font-family: 'Neue Haas Grotesk Display Pro';
-    font-weight: 200;
-    src: local('Neue Haas Grotesk Display 25 Thin'),
-    url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-25Th.otf') format('opentype');
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-weight: 200;
+  src: local('Neue Haas Grotesk Display Pro 25 Thin'),
+  url('../typefaces/neue-haas-grotesk-display/woff2/NHaasGroteskDSPro-25Th.woff2') format('woff2'),
+  url('../typefaces/neue-haas-grotesk-display/otf/NHaasGroteskDSPro-25Th.otf') format('opentype');
 }
 
 @font-face {
-    font-family: 'Neue Haas Grotesk Display Pro';
-    font-weight: 250;
-    src: local('Neue Haas Grotesk Display 35 Extra Light'),
-    url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-35XLt.otf') format('opentype');
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-weight: 250;
+  src: local('Neue Haas Grotesk Display Pro 35 Extra Light'),
+  url('../typefaces/neue-haas-grotesk-display/woff2/NHaasGroteskDSPro-35XLt.woff2') format('woff2'),
+  url('../typefaces/neue-haas-grotesk-display/otf/NHaasGroteskDSPro-35XLt.otf') format('opentype');
 }
 
 @font-face {
-    font-family: 'Neue Haas Grotesk Display Pro';
-    font-weight: 300;
-    src: local('Neue Haas Grotesk Display 45 Light'),
-    url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-45Lt.otf') format('opentype');
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-weight: 300;
+  src: local('Neue Haas Grotesk Display Pro 45 Light'),
+  url('../typefaces/neue-haas-grotesk-display/woff2/NHaasGroteskDSPro-45Lt.woff2') format('woff2'),
+  url('../typefaces/neue-haas-grotesk-display/otf/NHaasGroteskDSPro-45Lt.otf') format('opentype');
 }
 
 @font-face {
-    font-family: 'Neue Haas Grotesk Display Pro';
-    font-weight: 400;
-    src: local('Neue Haas Grotesk Display 55 Roman'),
-    url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-55Rg.otf') format('opentype');
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-weight: 400;
+  src: local('Neue Haas Grotesk Display Pro 55 Roman'),
+  url('../typefaces/neue-haas-grotesk-display/woff2/NHaasGroteskDSPro-55Rg.woff2') format('woff2'),
+  url('../typefaces/neue-haas-grotesk-display/otf/NHaasGroteskDSPro-55Rg.otf') format('opentype');
 }
 
 @font-face {
   font-family: 'Neue Haas Grotesk Display Pro';
   font-weight: 500;
-  src: local('Neue Haas Grotesk Display 65 Medium'),
-  url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-65Md.otf') format('opentype');
+  src: local('Neue Haas Grotesk Display Pro 65 Medium'),
+  url('../typefaces/neue-haas-grotesk-display/woff2/NHaasGroteskDSPro-65Md.woff2') format('woff2'),
+  url('../typefaces/neue-haas-grotesk-display/otf/NHaasGroteskDSPro-65Md.otf') format('opentype');
 }
 
 @font-face {
   font-family: 'Neue Haas Grotesk Display Pro';
   font-weight: 700;
-  src: local('Neue Haas Grotesk Display 75 Bold'),
-  url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-75Bd.otf') format('opentype');
+  src: local('Neue Haas Grotesk Display Pro 75 Bold'),
+  url('../typefaces/neue-haas-grotesk-display/woff2/NHaasGroteskDSPro-75Bd.woff2') format('woff2'),
+  url('../typefaces/neue-haas-grotesk-display/otf/NHaasGroteskDSPro-75Bd.otf') format('opentype');
 }
 
 @font-face {
   font-family: 'Neue Haas Grotesk Text Pro';
   font-weight: 400;
-  src: local('Neue Haas Grotesk Text 55 Roman'),
-  url('../typefaces/neue-haas-grotesk-text/NHaasGroteskTXPro-55Rg.otf') format('opentype');
+  src: local('Neue Haas Grotesk Text Pro 55 Roman'),
+  url('../typefaces/neue-haas-grotesk-text/woff2/NHaasGroteskTXPro-55Rg.woff2') format('woff2'),
+  url('../typefaces/neue-haas-grotesk-text/otf/NHaasGroteskTXPro-55Rg.otf') format('opentype');
 }
 
 @font-face {
   font-family: 'Neue Haas Grotesk Text Pro';
   font-weight: 400;
   font-style: italic;
-  src: local('Neue Haas Grotesk Text 56 Italic'),
-  url('../typefaces/neue-haas-grotesk-text/NHaasGroteskTXPro-56It.otf') format('opentype');
+  src: local('Neue Haas Grotesk Text Pro 56 Italic'),
+  url('../typefaces/neue-haas-grotesk-text/woff2/NHaasGroteskTXPro-56It.woff2') format('woff2'),
+  url('../typefaces/neue-haas-grotesk-text/otf/NHaasGroteskTXPro-56It.otf') format('opentype');
 }
 
 @font-face {
   font-family: 'Neue Haas Grotesk Text Pro';
   font-weight: 500;
-  src: local('Neue Haas Grotesk Text 65 Medium'),
-  url('../typefaces/neue-haas-grotesk-text/NHaasGroteskTXPro-65Md.otf') format('opentype');
+  src: local('Neue Haas Grotesk Text Pro 65 Medium'),
+  url('../typefaces/neue-haas-grotesk-text/woff2/NHaasGroteskTXPro-65Md.woff2') format('woff2'),
+  url('../typefaces/neue-haas-grotesk-text/otf/NHaasGroteskTXPro-65Md.otf') format('opentype');
 }

--- a/styles/type.css
+++ b/styles/type.css
@@ -1,44 +1,70 @@
 @font-face {
-    font-family: 'Neue Haas Grotesk Display';
-    font-display: auto;
+    font-family: 'Neue Haas Grotesk Display Pro';
+    font-weight: 100;
+    src: local('Neue Haas Grotesk Display Pro 15 Ultra Thin'),
+    url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-15UltTh.otf') format('opentype');
+}
+
+@font-face {
+    font-family: 'Neue Haas Grotesk Display Pro';
     font-weight: 200;
-    src: local('Neue Haas Grotesk Display Light'),
-    url('../typefaces/woff/NeueHaasGroteskDisplay-Light.woff') format('woff'),
-    url('../typefaces/otf/NeueHaasGroteskDisplay-Light.otf') format('opentype');
+    src: local('Neue Haas Grotesk Display 25 Thin'),
+    url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-25Th.otf') format('opentype');
 }
 
 @font-face {
-    font-family: 'Neue Haas Grotesk Display';
-    font-display: auto;
+    font-family: 'Neue Haas Grotesk Display Pro';
+    font-weight: 250;
+    src: local('Neue Haas Grotesk Display 35 Extra Light'),
+    url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-35XLt.otf') format('opentype');
+}
+
+@font-face {
+    font-family: 'Neue Haas Grotesk Display Pro';
     font-weight: 300;
-    src: local('Neue Haas Grotesk Display SemiLight'),
-    url('../typefaces/woff/NeueHaasGroteskDisplay-SemLt.woff') format('woff'),
-    url('../typefaces/otf/NeueHaasGroteskDisplay-SemLt.otf') format('opentype');
+    src: local('Neue Haas Grotesk Display 45 Light'),
+    url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-45Lt.otf') format('opentype');
 }
 
 @font-face {
-    font-family: 'Neue Haas Grotesk Display';
-    font-display: auto;
+    font-family: 'Neue Haas Grotesk Display Pro';
     font-weight: 400;
-    src: local('Neue Haas Grotesk Display Regular'),
-    url('../typefaces/woff/NeueHaasGroteskDisplay-Reg.woff') format('woff'),
-    url('../typefaces/otf/NeueHaasGroteskDisplay-Reg.otf') format('opentype');
+    src: local('Neue Haas Grotesk Display 55 Roman'),
+    url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-55Rg.otf') format('opentype');
 }
 
 @font-face {
-    font-family: 'Neue Haas Grotesk Display';
-    font-display: auto;
-    font-weight: 500;
-    src: local('Neue Haas Grotesk Display Medium'),
-    url('../typefaces/woff/NeueHaasGroteskDisplay-Medium.woff') format('woff'),
-    url('../typefaces/otf/NeueHaasGroteskDisplay-Medium.otf') format('opentype');
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-weight: 500;
+  src: local('Neue Haas Grotesk Display 65 Medium'),
+  url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-65Md.otf') format('opentype');
 }
 
 @font-face {
-    font-family: 'Neue Haas Grotesk Display';
-    font-display: auto;
-    font-weight: 600;
-    src: local('Neue Haas Grotesk Display Bold'),
-    url('../typefaces/woff/NeueHaasGroteskDisplay-Bold.woff') format('woff'),
-    url('../typefaces/otf/NeueHaasGroteskDisplay-Bold.otf') format('opentype');
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-weight: 700;
+  src: local('Neue Haas Grotesk Display 75 Bold'),
+  url('../typefaces/neue-haas-grotesk-display/NHaasGroteskDSPro-75Bd.otf') format('opentype');
+}
+
+@font-face {
+  font-family: 'Neue Haas Grotesk Text Pro';
+  font-weight: 400;
+  src: local('Neue Haas Grotesk Text 55 Roman'),
+  url('../typefaces/neue-haas-grotesk-text/NHaasGroteskTXPro-55Rg.otf') format('opentype');
+}
+
+@font-face {
+  font-family: 'Neue Haas Grotesk Text Pro';
+  font-weight: 400;
+  font-style: italic;
+  src: local('Neue Haas Grotesk Text 56 Italic'),
+  url('../typefaces/neue-haas-grotesk-text/NHaasGroteskTXPro-56It.otf') format('opentype');
+}
+
+@font-face {
+  font-family: 'Neue Haas Grotesk Text Pro';
+  font-weight: 500;
+  src: local('Neue Haas Grotesk Text 65 Medium'),
+  url('../typefaces/neue-haas-grotesk-text/NHaasGroteskTXPro-65Md.otf') format('opentype');
 }

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -2,7 +2,8 @@
     --primary-text--light-appearance: hsl(0deg 0% 20%);
     --primary-bg--light-appearance: hsl(0deg 100% 100%);
 
-    --primary-typeface: 'Neue Haas Grotesk Display';
+    --display-typeface: 'Neue Haas Grotesk Display Pro';
+    --text-typeface: 'Neue Haas Grotesk Text Pro';
 
     --content-width: 36em;
 }


### PR DESCRIPTION
Updates the font name used in this project, includes both a text and display variant in different weights, and ensures they are used for their correct purposes. Additionally provides both `otf` and `woff2` variants (the latter translated using FontForge).
